### PR TITLE
Fix missing firebaseUid on auth middleware

### DIFF
--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -33,8 +33,10 @@ const protect = async (req, res, next) => {
       const decodedToken = await admin.auth().verifyIdToken(token);
       
       // Add user info to request
+      // Some routes expect `firebaseUid`, so expose both properties
       req.user = {
         uid: decodedToken.uid,
+        firebaseUid: decodedToken.uid,
         email: decodedToken.email,
         emailVerified: decodedToken.email_verified
       };


### PR DESCRIPTION
## Summary
- expose `firebaseUid` property from Firebase auth token

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68778f7bbe808324b7c7913104c949ed