### PR TITLE
Update server instructions

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -49,7 +49,7 @@ npm install
 ### 5. Run the Server
 
 ```
-npm run dev
+npm start
 ```
 
-The server will run on port 5001 by default.
+This command starts the Express server. The server will run on port 5001 by default.


### PR DESCRIPTION
## Summary
- document using `npm start` instead of `npm run dev`
- clarify that `npm start` launches the Express server

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68779c7e8bc88324bc06e989248f1c94